### PR TITLE
Fix/jitpack jdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ You have to add Jitpack repository to your build file(ex. pom.xml, build.gradle)
     <dependency>
         <groupId>com.github.Ign1s-Reiga</groupId>
         <artifactId>Paperlin</artifactId>
-        <version>1.0.1</version>
+        <version>1.0.2</version>
     </dependency>
 </dependencies>
 
@@ -32,7 +32,7 @@ allProjects {
 }
 
 dependencies {
-    implementaion 'com.github.Ign1s-Reiga:Paperlin:1.0.1'
+    implementaion 'com.github.Ign1s-Reiga:Paperlin:1.0.2'
 }
 ```
 

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,1 @@
+jdk: openjdk11

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>dev.reiga7953</groupId>
-    <artifactId>SpiKotlin</artifactId>
+    <artifactId>Paperlin</artifactId>
     <version>1.0.0</version>
     <packaging>jar</packaging>
 
@@ -14,6 +14,8 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <kotlin.version>1.7.10</kotlin.version>
+        <kotlin.compiler.languageVersion>1.7</kotlin.compiler.languageVersion>
+        <kotlin.compiler.jvmTarget>11</kotlin.compiler.jvmTarget>
     </properties>
 
     <build>


### PR DESCRIPTION
## 概要
Using openjdk11 when build jar on jitpack
